### PR TITLE
Set up markdown editor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,8 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'slim-rails'
 gem 'devise'
 gem 'simple_form'
+gem 'redcarpet'
+gem 'rouge'
 
 group :development, :test do
   gem 'byebug', platforms: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,9 +169,11 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
+    redcarpet (3.4.0)
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rouge (3.3.0)
     rubocop (0.60.0)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -267,6 +269,8 @@ DEPENDENCIES
   pry-stack_explorer
   puma (~> 3.11)
   rails (~> 5.2.1)
+  redcarpet
+  rouge
   rubocop
   rubocop-rspec
   sass-rails (~> 5.0)

--- a/app/helpers/articles_helper.rb
+++ b/app/helpers/articles_helper.rb
@@ -1,4 +1,24 @@
 # frozen_string_literal: true
 
 module ArticlesHelper
+
+  def markdown(text)
+    options = {
+      filter_html:     true,
+      hard_wrap:       true,
+      space_after_headers: true,
+      with_toc_data: true
+    }
+
+    extensions = {
+      autolink:           true,
+      no_intra_emphasis:  true,
+      fenced_code_blocks: true,
+      tables:             true
+    }
+
+    renderer = Redcarpet::Render::HTML.new(options)
+    markdown = Redcarpet::Markdown.new(renderer, extensions)
+    markdown.render(text).html_safe
+  end
 end

--- a/app/views/articles/_form.html.slim
+++ b/app/views/articles/_form.html.slim
@@ -2,9 +2,25 @@
   = f.error_notification
   = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
 
-  .form-inputs
-    = f.input :title, required: true
-    = f.input :body, required: true
+  .form-group
+    = f.input :title, required: true, input_html: { class: 'form-control' }
+  #editor
+    = f.input :body, required: true, input_html: { class: 'form-control', debounce: 50, 'v-model':'input', rows: 20 }
+    div v-html=("input | marked")
+  .form-group
     = f.input :public, required: true
-  .form-actions
-    = f.button :submit
+  .form-group
+    = f.button :submit, class: 'btn btn-primary'
+
+  javascript:
+    window.onload = function() {
+      new Vue({
+        el: '#editor',
+        data: {
+          input: '#{j @article.body}',
+        },
+        filters: {
+          marked: marked,
+        },
+      });
+    };

--- a/app/views/articles/show.html.slim
+++ b/app/views/articles/show.html.slim
@@ -1,8 +1,10 @@
 p#notice = notice
 
 h1 = @article.title
-p = @article.body
 p = @article.public
 => link_to 'Edit', edit_article_path(@article)
 '|
 =< link_to 'Back', articles_path
+
+.markdown
+= markdown(@article.body)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -6,6 +6,8 @@ html
     = csrf_meta_tags
     = csp_meta_tag
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/vue/1.0.10/vue.js'
+    = javascript_include_tag 'https://cdnjs.cloudflare.com/ajax/libs/marked/0.3.5/marked.js'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   body
     = render 'layouts/shared/header'


### PR DESCRIPTION
# PRの目的
Markdownエディタ、リアルタイムプレビュー画面の実装

### markdownヘルパーのオプション
- エディタ上のhtmlはエスケープ
- 改行を改行として読み込む
- #の後にはスペースが必要
- 各ヘッダにアンカーリンクをつける
- リンクにはリンクを付与
- 文中のアンダーバーは強調として読み込まない
- コードを`で読み込む
- テーブルも有効
